### PR TITLE
Fix bug "ValueError: could not convert string to float"

### DIFF
--- a/checks/ip_global.py
+++ b/checks/ip_global.py
@@ -56,7 +56,9 @@ def check(global_params):
 
     # version dependent services
     if 'version' in global_params:
-        if float(global_params['version']) >= 12.1:
+        version_major, version_minor, version_build = global_params['version'].partition('.')
+        version = version_major + version_minor + version_build.replace('.', '')
+        if float(version) >= 12.1:
             if 'finger'   in global_params['ip']['active_service']:
                 results_dict['IP options']['service']['finger']   = [0, 'ENABLED', 'Disable it to prevent user to view other active users']
             else:

--- a/checks/services.py
+++ b/checks/services.py
@@ -49,13 +49,16 @@ def check(global_params):
 
     # version dependent services
     if 'version' in global_params:
-        if float(global_params['version']) < 12.1:
+        version_major, version_minor, version_build = global_params['version'].partition('.')
+        version = version_major + version_minor + version_build.replace('.', '')
+
+        if float(version) < 12.1:
             if 'finger' in global_params['disable_service']:
                 results_dict['Services']['finger']        = [2, 'DISABLED']
             else:
                 results_dict['Services']['finger']        = [0, 'ENABLED', 'Disable it to prevent user to view other active users']
 
-        if float(global_params['version']) >= 12.2:
+        if float(version) >= 12.2:
             if 'vstack' in global_params['disable_service']:
                 results_dict['Services']['smart install'] = [2, 'DISABLED']
             else:
@@ -63,12 +66,12 @@ def check(global_params):
 
         # TCP and UDP small services are enabled by default on Cisco IOS software Release 11.2 and earlier. These commands
         # are disabled by default on Cisco IOS software Software Versions 11.3 and later.
-        if 'udp small servers' not in results_dict['Services'] and float(global_params['version']) <= 11.2:
+        if 'udp small servers' not in results_dict['Services'] and float(version) <= 11.2:
             results_dict['Services']['udp small servers'] = [0, 'ENABLED', 'Turn it off to prevent potential information leak and DOS attack']
         else:
             results_dict['Services']['udp small servers'] = [2, 'DISABLED']
 
-        if 'tcp small servers' not in results_dict['Services'] and float(global_params['version']) <= 11.2:
+        if 'tcp small servers' not in results_dict['Services'] and float(version) <= 11.2:
             results_dict['Services']['tcp small servers'] = [0, 'ENABLED', 'Turn it off to prevent potential information leak and DOS attack']
         else:
             results_dict['Services']['tcp small servers'] = [2, 'DISABLED']


### PR DESCRIPTION
An error was occured while analysing extended version in config file:
```
version 16.3.2
```

Error listing:
```
Traceback (most recent call last):
  File "./ccat.py", line 94, in <module>
    result_dict.update(checks.services.check(global_params))
  File "/opt/ccat/checks/services.py", line 52, in check
    if float(global_params['version']) < 12.1:
ValueError: could not convert string to float: '16.3.1'
```
```
Traceback (most recent call last):
  File "./ccat.py", line 96, in <module>
    result_dict.update(checks.ip_global.check(global_params))
  File "/opt/ccat/checks/ip_global.py", line 59, in check
    if float(global_params['version']) >= 12.1:
ValueError: could not convert string to float: '16.3.1'
```